### PR TITLE
SQLSRV: Set WarningsReturnAsErrors = 0 before connection

### DIFF
--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -130,7 +130,6 @@ class Connection extends BaseConnection
 		}
 
 		sqlsrv_configure('WarningsReturnAsErrors', 0);
-		
 		$this->connID = sqlsrv_connect($this->hostname, $connection);
 
 		if ($this->connID !== false)

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -129,12 +129,12 @@ class Connection extends BaseConnection
 			unset($connection['UID'], $connection['PWD']);
 		}
 
+		sqlsrv_configure('WarningsReturnAsErrors', 0);
+		
 		$this->connID = sqlsrv_connect($this->hostname, $connection);
 
 		if ($this->connID !== false)
 		{
-			sqlsrv_configure('WarningsReturnAsErrors', 0);
-
 			// Determine how identifiers are escaped
 			$query = $this->query('SELECT CASE WHEN (@@OPTIONS | 256) = @@OPTIONS THEN 1 ELSE 0 END AS qi');
 			$query = $query->getResultObject();


### PR DESCRIPTION
Description
We have moved `sqlsrv_configure('WarningsReturnAsErrors', 0);` prior to `sqlsrv_connect($this->hostname, $connection)` because if there is a warning or an information message establishing the connection, it will treat it as an error and Codeigniter will throw an exception. It should be configured prior the connection.

Example:
Before change, exception shows up (image1): "Unable to connect to the database. Main connection [SQLSRV]: Driver's SQLSetConnectAttr failed", but it is thrown by information message (IM006), as we can see when executing `sqlsrv_errors()` (image2).
Image1:
![before](https://user-images.githubusercontent.com/50045374/120232960-f8137c00-c254-11eb-8828-6b7629bf90a9.png)
Image2
![information message](https://user-images.githubusercontent.com/50045374/120232965-f9dd3f80-c254-11eb-9398-1ab7fd7f6988.png)

After change: Connection is established without problems:
![after](https://user-images.githubusercontent.com/50045374/120232966-fa75d600-c254-11eb-99a1-0ee47523a3a6.png)


**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
  
